### PR TITLE
Do not ignore attributes

### DIFF
--- a/lib/xmlhasher/configurable.rb
+++ b/lib/xmlhasher/configurable.rb
@@ -3,7 +3,7 @@ module XmlHasher
 
     attr_writer :snakecase, :ignore_namespaces, :string_keys
 
-    KEYS = [:snakecase, :ignore_namespaces, :string_keys]
+    KEYS = [:snakecase, :ignore_namespaces, :string_keys, :ignore_attributes_on_content]
 
     def configure
       yield self

--- a/lib/xmlhasher/handler.rb
+++ b/lib/xmlhasher/handler.rb
@@ -13,7 +13,7 @@ module XmlHasher
     end
 
     def start_element(name)
-      @stack.push(Node.new(transform(name)))
+      @stack.push(Node.new(transform(name), @options[:ignore_attributes_on_content]))
     end
 
     def attr(name, value)

--- a/lib/xmlhasher/node.rb
+++ b/lib/xmlhasher/node.rb
@@ -11,9 +11,13 @@ module XmlHasher
     def to_hash
       h = {}
       if text
-        h[name] = text
+        if clean_attributes.empty?
+          h[name] = text
+        else
+          h[name] = clean_attributes.merge(value: text)
+        end
       else
-        h[name] = attributes.inject({}) { |r, (key, value)| r[key] = value if !value.nil? && !value.to_s.empty?; r }
+        h[name] = clean_attributes
         if children.size == 1
           child = children.first
           h[name].merge!(child.to_hash)
@@ -24,6 +28,12 @@ module XmlHasher
       h[name] = nil if h[name].empty?
       h
     end
+
+    private
+
+    def clean_attributes
+      return @clean_attributes if @clean_attributes
+      @clean_attributes = attributes.inject({}) { |r, (key, value)| r[key] = value if !value.nil? && !value.to_s.empty?; r }
+    end
   end
 end
-

--- a/lib/xmlhasher/node.rb
+++ b/lib/xmlhasher/node.rb
@@ -2,16 +2,17 @@ module XmlHasher
   class Node
     attr_accessor :name, :attributes, :children, :text
 
-    def initialize(name)
+    def initialize(name, ignore_attributes_on_content = false)
       @name = name
       @attributes = {}
       @children = []
+      @ignore_attributes_on_content = ignore_attributes_on_content
     end
 
     def to_hash
       h = {}
       if text
-        if clean_attributes.empty?
+        if should_ignore_attributes_on_content?
           h[name] = text
         else
           h[name] = clean_attributes.merge(value: text)
@@ -30,6 +31,10 @@ module XmlHasher
     end
 
     private
+
+    def should_ignore_attributes_on_content?
+      @ignore_attributes_on_content || clean_attributes.empty?
+    end
 
     def clean_attributes
       return @clean_attributes if @clean_attributes

--- a/lib/xmlhasher/version.rb
+++ b/lib/xmlhasher/version.rb
@@ -1,3 +1,3 @@
 module XmlHasher
-  VERSION = '0.0.6'
+  VERSION = '1.0.0'
 end

--- a/test/xmlhasher/parser_test.rb
+++ b/test/xmlhasher/parser_test.rb
@@ -172,9 +172,15 @@ class XmlhasherTest < Test::Unit::TestCase
     assert_equal expected, XmlHasher::Parser.new.parse(xml)
   end
 
-  def test_ignore_attributes_if_has_content
+  def test_do_not_ignore_attributes_if_has_content
     xml = %[<tag a1='1' a2='2'>content</tag>]
-    expected = {:tag => 'content'}
+    expected = {:tag => {:a1 =>'1', :a2 => '2', :value => 'content'}}
+    assert_equal expected, XmlHasher::Parser.new.parse(xml)
+  end
+
+  def test_override_value_attribute_if_has_content
+    xml = %[<tag a1='1' value='2'>content</tag>]
+    expected = {:tag => {:a1 =>'1', :value => 'content'}}
     assert_equal expected, XmlHasher::Parser.new.parse(xml)
   end
 

--- a/test/xmlhasher/parser_test.rb
+++ b/test/xmlhasher/parser_test.rb
@@ -172,10 +172,24 @@ class XmlhasherTest < Test::Unit::TestCase
     assert_equal expected, XmlHasher::Parser.new.parse(xml)
   end
 
+  def test_ignore_attributes_on_content
+    options = {
+      :ignore_attributes_on_content => true
+    }
+    expected = {:tag => 'content'}
+    xml = %[<tag a1='1' a2='2'>content</tag>]
+    assert_equal expected, XmlHasher::Parser.new(options).parse(xml)
+  end
+
   def test_do_not_ignore_attributes_if_has_content
     xml = %[<tag a1='1' a2='2'>content</tag>]
     expected = {:tag => {:a1 =>'1', :a2 => '2', :value => 'content'}}
     assert_equal expected, XmlHasher::Parser.new.parse(xml)
+
+    options = {
+      :ignore_attributes_on_content => false
+    }
+    assert_equal expected, XmlHasher::Parser.new(options).parse(xml)
   end
 
   def test_override_value_attribute_if_has_content


### PR DESCRIPTION
Hi.
In my opinion when attributes are present in tag they always should be returned.
I bumped major because changes can break hashes parsed by 0.0.x version. 
