### PR TITLE
Enable CDATA parsing

### DIFF
--- a/lib/xmlhasher/handler.rb
+++ b/lib/xmlhasher/handler.rb
@@ -26,6 +26,10 @@ module XmlHasher
       @stack.last.text = escape(value)
     end
 
+    def cdata(str)
+      @stack.last.text = escape(str)
+    end
+
     def end_element(name)
       if @stack.size == 1
         @hash = @stack.pop.to_hash

--- a/test/xmlhasher/parser_test.rb
+++ b/test/xmlhasher/parser_test.rb
@@ -241,4 +241,10 @@ class XmlhasherTest < Test::Unit::TestCase
     expected = {:tag => nil}
     assert_equal expected, XmlHasher::Parser.new.parse(xml)
   end
+
+  def test_cdata_value
+    xml = %[<title><![CDATA[Midhir uploaded a photo.]]></title>]
+    expected = {:title => "Midhir uploaded a photo."}
+    assert_equal expected, XmlHasher::Parser.new.parse(xml)
+  end
 end


### PR DESCRIPTION
Fixes issue https://github.com/cloocher/xmlhasher/issues/4

- Enables parsing of CDATA elements to text where previously they were nullified.