### PR TITLE
Resolve gem build warnings

### DIFF
--- a/xmlhasher.gemspec
+++ b/xmlhasher.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.6'
 
   spec.add_dependency 'escape_utils', '~> 1.2'
-  spec.add_dependency 'ox', '~> 2.11.0'
+  spec.add_dependency 'ox', '~> 2.11'
 
-  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'coveralls', '~> 0.8.21'
   spec.add_development_dependency 'minitest', '~> 5.10'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 12'
   spec.add_development_dependency 'simplecov', '~> 0.14.1'
   spec.add_development_dependency 'test-unit', '~> 3.2'
 end


### PR DESCRIPTION
Resolve for next warnings:
```bash
$ gem build xmlhasher.gemspec
WARNING:  open-ended dependency on bundler (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: xmlhasher
  Version: 1.0.5
  File: xmlhasher-1.0.5.gem
```