### PR TITLE
Fix string_keys to work when it's the only option specified

### DIFF
--- a/lib/xmlhasher/handler.rb
+++ b/lib/xmlhasher/handler.rb
@@ -51,7 +51,7 @@ module XmlHasher
 
       name = name.to_s.split(':').last if @options[:ignore_namespaces]
       name = Util.snakecase(name) if @options[:snakecase]
-      name = name.to_sym unless @options[:string_keys]
+      name = @options[:string_keys] ? name.to_s : name.to_sym
       @transform_cache[orig_name] = name
       name
     end

--- a/test/xmlhasher/parser_test.rb
+++ b/test/xmlhasher/parser_test.rb
@@ -241,6 +241,15 @@ class XmlhasherTest < Test::Unit::TestCase
     assert_equal expected, XmlHasher::Parser.new(options).parse(xml)
   end
 
+  def test_string_elements
+    options = {
+      string_keys: true
+    }
+    xml = %(<my-tag><MyTag2>content</MyTag2></my-tag>)
+    expected = { 'my-tag' => { 'MyTag2' => 'content' } }
+    assert_equal expected, XmlHasher::Parser.new(options).parse(xml)
+  end
+
   def test_empty_tag
     xml = %(<tag></tag>)
     expected = { tag: nil }


### PR DESCRIPTION
If string_keys was set without any other options, it wouldn't work since "name" variable is initially a symbol.

Fix #24.