### PR TITLE
Fix | EscapeUtils.unescape_html is deprecated

### DIFF
--- a/lib/xmlhasher/handler.rb
+++ b/lib/xmlhasher/handler.rb
@@ -59,7 +59,7 @@ module XmlHasher
     end
 
     def escape(value)
-      EscapeUtils.unescape_html(value)
+      CGI.unescapeHTML(value)
     end
 
     def ignore_attribute?(name)


### PR DESCRIPTION
Replacing EscapeUtils with CGI due to deprecation warning.

`EscapeUtils.unescape_html is deprecated. Use GCI.unescapeHTML instead, performance is similar`